### PR TITLE
Reduce FPS to camera's FPS to achieve real time video lengths

### DIFF
--- a/scripts/video_recording.py
+++ b/scripts/video_recording.py
@@ -59,7 +59,7 @@ class VideoRecorder:
 
         self.out = cv2.VideoWriter(filename,
                                    fourcc_code,
-                                   30,
+                                   24,
                                    frame_dims)
         return True
 


### PR DESCRIPTION
Previously the FPS of 30 resulted in videos that were 30/24 = 1.25x real time